### PR TITLE
Hashtable implementation

### DIFF
--- a/hashtable.cpp
+++ b/hashtable.cpp
@@ -1,0 +1,124 @@
+#include <assert.h>
+#include <stdlib.h>     // calloc(), free()
+#include "hashtable.h"
+
+// n must be a power of 2
+static void h_init(HTab *htab, size_t n) {
+    assert(n > 0 && ((n - 1) & n) == 0);
+    htab->tab = (HNode **)calloc(n, sizeof(HNode *));
+    htab->mask = n - 1;
+    htab->size = 0;
+}
+
+// hashtable insertion
+static void h_insert(HTab *htab, HNode *node) {
+    size_t pos = node->hcode & htab->mask;
+    HNode *next = htab->tab[pos];
+    node->next = next;
+    htab->tab[pos] = node;
+    htab->size++;
+}
+
+// hashtable look up subroutine.
+// Pay attention to the return value. It returns the address of
+// the parent pointer that owns the target node,
+// which can be used to delete the target node.
+static HNode **h_lookup(HTab *htab, HNode *key, bool (*eq)(HNode *, HNode *)) {
+    if (!htab->tab) {
+        return NULL;
+    }
+
+    size_t pos = key->hcode & htab->mask;
+    HNode **from = &htab->tab[pos];     // incoming pointer to the target
+    for (HNode *cur; (cur = *from) != NULL; from = &cur->next) {
+        if (cur->hcode == key->hcode && eq(cur, key)) {
+            return from;                // may be a node, may be a slot
+        }
+    }
+    return NULL;
+}
+
+// remove a node from the chain
+static HNode *h_detach(HTab *htab, HNode **from) {
+    HNode *node = *from;    // the target node
+    *from = node->next;     // update the incoming pointer to the target
+    htab->size--;
+    return node;
+}
+
+const size_t k_rehashing_work = 128;    // constant work
+
+static void hm_help_rehashing(HMap *hmap) {
+    size_t nwork = 0;
+    while (nwork < k_rehashing_work && hmap->older.size > 0) {
+        // find a non-empty slot
+        HNode **from = &hmap->older.tab[hmap->migrate_pos];
+        if (!*from) {
+            hmap->migrate_pos++;
+            continue;   // empty slot
+        }
+        // move the first list item to the newer table
+        h_insert(&hmap->newer, h_detach(&hmap->older, from));
+        nwork++;
+    }
+    // discard the old table if done
+    if (hmap->older.size == 0 && hmap->older.tab) {
+        free(hmap->older.tab);
+        hmap->older = HTab{};
+    }
+}
+
+static void hm_trigger_rehashing(HMap *hmap) {
+    assert(hmap->older.tab == NULL);
+    // (newer, older) <- (new_table, newer)
+    hmap->older = hmap->newer;
+    h_init(&hmap->newer, (hmap->newer.mask + 1) * 2);
+    hmap->migrate_pos = 0;
+}
+
+HNode *hm_lookup(HMap *hmap, HNode *key, bool (*eq)(HNode *, HNode *)) {
+    hm_help_rehashing(hmap);
+    HNode **from = h_lookup(&hmap->newer, key, eq);
+    if (!from) {
+        from = h_lookup(&hmap->older, key, eq);
+    }
+    return from ? *from : NULL;
+}
+
+const size_t k_max_load_factor = 8;
+
+void hm_insert(HMap *hmap, HNode *node) {
+    if (!hmap->newer.tab) {
+        h_init(&hmap->newer, 4);    // initialize it if empty
+    }
+    h_insert(&hmap->newer, node);   // always insert to the newer table
+
+    if (!hmap->older.tab) {         // check whether we need to rehash
+        size_t shreshold = (hmap->newer.mask + 1) * k_max_load_factor;
+        if (hmap->newer.size >= shreshold) {
+            hm_trigger_rehashing(hmap);
+        }
+    }
+    hm_help_rehashing(hmap);        // migrate some keys
+}
+
+HNode *hm_delete(HMap *hmap, HNode *key, bool (*eq)(HNode *, HNode *)) {
+    hm_help_rehashing(hmap);
+    if (HNode **from = h_lookup(&hmap->newer, key, eq)) {
+        return h_detach(&hmap->newer, from);
+    }
+    if (HNode **from = h_lookup(&hmap->older, key, eq)) {
+        return h_detach(&hmap->older, from);
+    }
+    return NULL;
+}
+
+void hm_clear(HMap *hmap) {
+    free(hmap->newer.tab);
+    free(hmap->older.tab);
+    *hmap = HMap{};
+}
+
+size_t hm_size(HMap *hmap) {
+    return hmap->newer.size + hmap->older.size;
+}

--- a/hashtable.h
+++ b/hashtable.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct HNode {
+    HNode *next = NULL;
+    uint64_t hcode = 0;
+};
+
+// a simple fixed-sized hashtable
+struct HTab {
+    HNode **tab = NULL; // array of slots
+    size_t mask = 0;    // power of 2 array size, 2^n - 1
+    size_t size = 0;    // number of keys
+};
+
+// the real hashtable interface with progressive rehashing
+struct HMap {
+    HTab newer;
+    HTab older;
+    size_t migrate_pos = 0;
+};
+
+HNode *hm_lookup(HMap *hmap, HNode *key, bool (*eq)(HNode *, HNode *));
+void   hm_insert(HMap *hmap, HNode *node);
+HNode *hm_delete(HMap *hmap, HNode *key, bool (*eq)(HNode *, HNode *));
+void   hm_clear(HMap *hmap);
+size_t hm_size(HMap *hmap);

--- a/server.cpp
+++ b/server.cpp
@@ -12,7 +12,10 @@
 #include <netinet/ip.h>
 #include <string>
 #include <vector>
-#include <map>
+#include "hashtable.h"
+
+#define container_of(ptr, T, member) \
+    ((T *)( (char *)ptr - offsetof(T, member) ))
 
 static void msg(const char *msg) {
     fprintf(stderr, "%s\n", msg);
@@ -157,22 +160,90 @@ struct Response {
     std::vector<uint8_t> data;
 };
 
-// placeholder, to be implemented
-static std::map<std::string, std::string> g_data;
+// global states
+static struct {
+    HMap db;    // top-level hashtable
+} g_data;
+
+// KV pair for the top-level hashtable
+struct Entry {
+    struct HNode node;  // hashtable node
+    std::string key;
+    std::string val;
+};
+
+// equality comparison for `struct Entry`
+static bool entry_eq(HNode *lhs, HNode *rhs) {
+    struct Entry *le = container_of(lhs, struct Entry, node);
+    struct Entry *re = container_of(rhs, struct Entry, node);
+    return le->key == re->key;
+}
+
+// FNV hash
+static uint64_t str_hash(const uint8_t *data, size_t len) {
+    uint32_t h = 0x811C9DC5;
+    for (size_t i = 0; i < len; i++) {
+        h = (h + data[i]) * 0x01000193;
+    }
+    return h;
+}
+
+static void do_get(std::vector<std::string> &cmd, Response &out) {
+    // a dummy `Entry` just for the lookup
+    Entry key;
+    key.key.swap(cmd[1]);
+    key.node.hcode = str_hash((uint8_t *)key.key.data(), key.key.size());
+    // hashtable lookup
+    HNode *node = hm_lookup(&g_data.db, &key.node, &entry_eq);
+    if (!node) {
+        out.status = RES_NX;
+        return;
+    }
+    // copy the value
+    const std::string &val = container_of(node, Entry, node)->val;
+    assert(val.size() <= k_max_msg);
+    out.data.assign(val.begin(), val.end());
+}
+
+static void do_set(std::vector<std::string> &cmd, Response &) {
+    // a dummy `Entry` just for the lookup
+    Entry key;
+    key.key.swap(cmd[1]);
+    key.node.hcode = str_hash((uint8_t *)key.key.data(), key.key.size());
+    // hashtable lookup
+    HNode *node = hm_lookup(&g_data.db, &key.node, &entry_eq);
+    if (node) {
+        // found, update the value
+        container_of(node, Entry, node)->val.swap(cmd[2]);
+    } else {
+        // not found, allocate & insert a new pair
+        Entry *ent = new Entry();
+        ent->key.swap(key.key);
+        ent->node.hcode = key.node.hcode;
+        ent->val.swap(cmd[2]);
+        hm_insert(&g_data.db, &ent->node);
+    }
+}
+
+static void do_del(std::vector<std::string> &cmd, Response &) {
+    // a dummy `Entry` just for the lookup
+    Entry key;
+    key.key.swap(cmd[1]);
+    key.node.hcode = str_hash((uint8_t *)key.key.data(), key.key.size());
+    // hashtable delete
+    HNode *node = hm_delete(&g_data.db, &key.node, &entry_eq);
+    if (node) { // deallocate the pair
+        delete container_of(node, Entry, node);
+    }
+}
 
 static void do_request(std::vector<std::string> &cmd, Response &out) {
     if (cmd.size() == 2 && cmd[0] == "get") {
-        auto it = g_data.find(cmd[1]);
-        if (it == g_data.end()) {
-            out.status = RES_NX;    // not found
-            return;
-        }
-        const std::string &val = it->second;
-        out.data.assign(val.begin(), val.end());
+        return do_get(cmd, out);
     } else if (cmd.size() == 3 && cmd[0] == "set") {
-        g_data[cmd[1]].swap(cmd[2]);
+        return do_set(cmd, out);
     } else if (cmd.size() == 2 && cmd[0] == "del") {
-        g_data.erase(cmd[1]);
+        return do_del(cmd, out);
     } else {
         out.status = RES_ERR;       // unrecognized command
     }


### PR DESCRIPTION
Replaces `std::map` with a custom `HMap` in `server.cpp`, featuring power-of-two bucket sizing, FNV hashing, and two-table progressive migration to eliminate O(N) stalls. Core APIs (`insert`, `lookup`, `delete`) live in `hashtable.h/.cpp`, and command handlers (`get`, `set`, `del`) now dispatch via `HMap`, improving average lookup and insertion performance.