### PR TITLE
implemented serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ A learning-oriented, minimal Redis‑like server written in C++ with a tiny clie
 * [x] Single‑threaded TCP server that accepts multiple clients (non‑blocking sockets + event loop)
 * [x] Pipelined requests to increase the amount of work per IO
 * [x] String KV store implemented by chaining hashtable with progressive rehashing
-* [x] Basic Redis commands: `get`, `set`, `del`
-* [ ] A simple JSON-like data serialization
+* [x] Basic Redis commands: `get`, `set`, `del`, `keys`
+* [x] A simple JSON-like data serialization
 * [ ] Sorted set interfaces
 * [ ] Cache expiration with TTL
 * [ ] Multithreading with a concurrent queue

--- a/client.cpp
+++ b/client.cpp
@@ -72,6 +72,104 @@ static int32_t send_req(int fd, const std::vector<std::string> &cmd) {
     return write_all(fd, wbuf, 4 + len);
 }
 
+enum {
+    TAG_NIL = 0,    // nil
+    TAG_ERR = 1,    // error code + msg
+    TAG_STR = 2,    // string
+    TAG_INT = 3,    // int64
+    TAG_DBL = 4,    // double
+    TAG_ARR = 5,    // array
+};
+
+static int32_t print_response(const uint8_t *data, size_t size) {
+    if (size < 1) {
+        msg("bad response");
+        return -1;
+    }
+    switch (data[0]) {
+    case TAG_NIL:
+        printf("(nil)\n");
+        return 1;
+    case TAG_ERR:
+        if (size < 1 + 8) {
+            msg("bad response");
+            return -1;
+        }
+        {
+            int32_t code = 0;
+            uint32_t len = 0;
+            memcpy(&code, &data[1], 4);
+            memcpy(&len, &data[1 + 4], 4);
+            if (size < 1 + 8 + len) {
+                msg("bad response");
+                return -1;
+            }
+            printf("(err) %d %.*s\n", code, len, &data[1 + 8]);
+            return 1 + 8 + len;
+        }
+    case TAG_STR:
+        if (size < 1 + 4) {
+            msg("bad response");
+            return -1;
+        }
+        {
+            uint32_t len = 0;
+            memcpy(&len, &data[1], 4);
+            if (size < 1 + 4 + len) {
+                msg("bad response");
+                return -1;
+            }
+            printf("(str) %.*s\n", len, &data[1 + 4]);
+            return 1 + 4 + len;
+        }
+    case TAG_INT:
+        if (size < 1 + 8) {
+            msg("bad response");
+            return -1;
+        }
+        {
+            int64_t val = 0;
+            memcpy(&val, &data[1], 8);
+            printf("(int) %ld\n", val);
+            return 1 + 8;
+        }
+    case TAG_DBL:
+        if (size < 1 + 8) {
+            msg("bad response");
+            return -1;
+        }
+        {
+            double val = 0;
+            memcpy(&val, &data[1], 8);
+            printf("(dbl) %g\n", val);
+            return 1 + 8;
+        }
+    case TAG_ARR:
+        if (size < 1 + 4) {
+            msg("bad response");
+            return -1;
+        }
+        {
+            uint32_t len = 0;
+            memcpy(&len, &data[1], 4);
+            printf("(arr) len=%u\n", len);
+            size_t arr_bytes = 1 + 4;
+            for (uint32_t i = 0; i < len; ++i) {
+                int32_t rv = print_response(&data[arr_bytes], size - arr_bytes);
+                if (rv < 0) {
+                    return rv;
+                }
+                arr_bytes += (size_t)rv;
+            }
+            printf("(arr) end\n");
+            return (int32_t)arr_bytes;
+        }
+    default:
+        msg("bad response");
+        return -1;
+    }
+}
+
 static int32_t read_res(int fd) {
     // 4 bytes header
     char rbuf[4 + k_max_msg + 1];
@@ -101,14 +199,12 @@ static int32_t read_res(int fd) {
     }
 
     // print the result
-    uint32_t rescode = 0;
-    if (len < 4) {
+    int32_t rv = print_response((uint8_t *)&rbuf[4], len);
+    if (rv > 0 && (uint32_t)rv != len) {
         msg("bad response");
-        return -1;
+        rv = -1;
     }
-    memcpy(&rescode, &rbuf[4], 4);
-    printf("server says: [%u] %.*s\n", rescode, len - 4, &rbuf[8]);
-    return 0;
+    return rv;
 }
 
 int main(int argc, char **argv) {

--- a/hashtable.cpp
+++ b/hashtable.cpp
@@ -122,3 +122,18 @@ void hm_clear(HMap *hmap) {
 size_t hm_size(HMap *hmap) {
     return hmap->newer.size + hmap->older.size;
 }
+
+static bool h_foreach(HTab *htab, bool (*f)(HNode *, void *), void *arg) {
+    for (size_t i = 0; htab->mask != 0 && i <= htab->mask; i++) {
+        for (HNode *node = htab->tab[i]; node != NULL; node = node->next) {
+            if (!f(node, arg)) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+void hm_foreach(HMap *hmap, bool (*f)(HNode *, void *), void *arg) {
+    h_foreach(&hmap->newer, f, arg) && h_foreach(&hmap->older, f, arg);
+}

--- a/hashtable.h
+++ b/hashtable.h
@@ -27,3 +27,5 @@ void   hm_insert(HMap *hmap, HNode *node);
 HNode *hm_delete(HMap *hmap, HNode *key, bool (*eq)(HNode *, HNode *));
 void   hm_clear(HMap *hmap);
 size_t hm_size(HMap *hmap);
+// invoke the callback on each node until it returns false
+void   hm_foreach(HMap *hmap, bool (*f)(HNode *, void *), void *arg);

--- a/server.cpp
+++ b/server.cpp
@@ -50,6 +50,17 @@ static void fd_set_nb(int fd) {
 
 const size_t k_max_msg = 32 << 20;  // likely larger than the kernel buffer
 
+typedef std::vector<uint8_t> Buffer;
+
+// append to the back
+static void buf_append(Buffer &buf, const uint8_t *data, size_t len) {
+    buf.insert(buf.end(), data, data + len);
+}
+// remove from the front
+static void buf_consume(Buffer &buf, size_t n) {
+    buf.erase(buf.begin(), buf.begin() + n);
+}
+
 struct Conn {
     int fd = -1;
     // application's intention, for the event loop
@@ -60,14 +71,6 @@ struct Conn {
     std::vector<uint8_t> incoming;
     std::vector<uint8_t> outgoing;
 };
-
-static void buf_append(std::vector<uint8_t> &buf, const uint8_t *data, size_t len) {
-    buf.insert(buf.end(), data, data + len);
-}
-
-static void buf_consume(std::vector<uint8_t> &buf, size_t n) {
-    buf.erase(buf.begin(), buf.begin() + n);
-}
 
 // application callback when the listening socket is ready
 static Conn *handle_accept(int fd) {
@@ -145,20 +148,63 @@ static int32_t parse_req(const uint8_t *data, size_t size, std::vector<std::stri
     return 0;
 }
 
-// Response::status
+// error code for TAG_ERR
 enum {
-    RES_OK = 0,
-    RES_ERR = 1,    // error
-    RES_NX = 2,     // key not found
+    ERR_UNKNOWN = 1,    // unknown command
+    ERR_TOO_BIG = 2,    // response too big
 };
 
-// +--------+---------+
-// | status | data... |
-// +--------+---------+
-struct Response {
-    uint32_t status = 0;
-    std::vector<uint8_t> data;
+// data types of serialized data
+enum {
+    TAG_NIL = 0,    // nil
+    TAG_ERR = 1,    // error code + msg
+    TAG_STR = 2,    // string
+    TAG_INT = 3,    // int64
+    TAG_DBL = 4,    // double
+    TAG_ARR = 5,    // array
 };
+
+// help functions for the serialization
+static void buf_append_u8(Buffer &buf, uint8_t data) {
+    buf.push_back(data);
+}
+static void buf_append_u32(Buffer &buf, uint32_t data) {
+    buf_append(buf, (const uint8_t *)&data, 4);
+}
+static void buf_append_i64(Buffer &buf, int64_t data) {
+    buf_append(buf, (const uint8_t *)&data, 8);
+}
+static void buf_append_dbl(Buffer &buf, double data) {
+    buf_append(buf, (const uint8_t *)&data, 8);
+}
+
+// append serialized data types to the back
+static void out_nil(Buffer &out) {
+    buf_append_u8(out, TAG_NIL);
+}
+static void out_str(Buffer &out, const char *s, size_t size) {
+    buf_append_u8(out, TAG_STR);
+    buf_append_u32(out, (uint32_t)size);
+    buf_append(out, (const uint8_t *)s, size);
+}
+static void out_int(Buffer &out, int64_t val) {
+    buf_append_u8(out, TAG_INT);
+    buf_append_i64(out, val);
+}
+static void out_dbl(Buffer &out, double val) {
+    buf_append_u8(out, TAG_DBL);
+    buf_append_dbl(out, val);
+}
+static void out_err(Buffer &out, uint32_t code, const std::string &msg) {
+    buf_append_u8(out, TAG_ERR);
+    buf_append_u32(out, code);
+    buf_append_u32(out, (uint32_t)msg.size());
+    buf_append(out, (const uint8_t *)msg.data(), msg.size());
+}
+static void out_arr(Buffer &out, uint32_t n) {
+    buf_append_u8(out, TAG_ARR);
+    buf_append_u32(out, n);
+}
 
 // global states
 static struct {
@@ -188,7 +234,7 @@ static uint64_t str_hash(const uint8_t *data, size_t len) {
     return h;
 }
 
-static void do_get(std::vector<std::string> &cmd, Response &out) {
+static void do_get(std::vector<std::string> &cmd, Buffer &out) {
     // a dummy `Entry` just for the lookup
     Entry key;
     key.key.swap(cmd[1]);
@@ -196,16 +242,14 @@ static void do_get(std::vector<std::string> &cmd, Response &out) {
     // hashtable lookup
     HNode *node = hm_lookup(&g_data.db, &key.node, &entry_eq);
     if (!node) {
-        out.status = RES_NX;
-        return;
+        return out_nil(out);
     }
     // copy the value
     const std::string &val = container_of(node, Entry, node)->val;
-    assert(val.size() <= k_max_msg);
-    out.data.assign(val.begin(), val.end());
+    return out_str(out, val.data(), val.size());
 }
 
-static void do_set(std::vector<std::string> &cmd, Response &) {
+static void do_set(std::vector<std::string> &cmd, Buffer &out) {
     // a dummy `Entry` just for the lookup
     Entry key;
     key.key.swap(cmd[1]);
@@ -223,9 +267,10 @@ static void do_set(std::vector<std::string> &cmd, Response &) {
         ent->val.swap(cmd[2]);
         hm_insert(&g_data.db, &ent->node);
     }
+    return out_nil(out);
 }
 
-static void do_del(std::vector<std::string> &cmd, Response &) {
+static void do_del(std::vector<std::string> &cmd, Buffer &out) {
     // a dummy `Entry` just for the lookup
     Entry key;
     key.key.swap(cmd[1]);
@@ -235,25 +280,52 @@ static void do_del(std::vector<std::string> &cmd, Response &) {
     if (node) { // deallocate the pair
         delete container_of(node, Entry, node);
     }
+    return out_int(out, node ? 1 : 0);
 }
 
-static void do_request(std::vector<std::string> &cmd, Response &out) {
+static bool cb_keys(HNode *node, void *arg) {
+    Buffer &out = *(Buffer *)arg;
+    const std::string &key = container_of(node, Entry, node)->key;
+    out_str(out, key.data(), key.size());
+    return true;
+}
+
+static void do_keys(std::vector<std::string> &, Buffer &out) {
+    out_arr(out, (uint32_t)hm_size(&g_data.db));
+    hm_foreach(&g_data.db, &cb_keys, (void *)&out);
+}
+
+static void do_request(std::vector<std::string> &cmd, Buffer &out) {
     if (cmd.size() == 2 && cmd[0] == "get") {
         return do_get(cmd, out);
     } else if (cmd.size() == 3 && cmd[0] == "set") {
         return do_set(cmd, out);
     } else if (cmd.size() == 2 && cmd[0] == "del") {
         return do_del(cmd, out);
+    } else if (cmd.size() == 1 && cmd[0] == "keys") {
+        return do_keys(cmd, out);
     } else {
-        out.status = RES_ERR;       // unrecognized command
+        return out_err(out, ERR_UNKNOWN, "unknown command.");
     }
 }
 
-static void make_response(const Response &resp, std::vector<uint8_t> &out) {
-    uint32_t resp_len = 4 + (uint32_t)resp.data.size();
-    buf_append(out, (const uint8_t *)&resp_len, 4);
-    buf_append(out, (const uint8_t *)&resp.status, 4);
-    buf_append(out, resp.data.data(), resp.data.size());
+static void response_begin(Buffer &out, size_t *header) {
+    *header = out.size();       // messege header position
+    buf_append_u32(out, 0);     // reserve space
+}
+static size_t response_size(Buffer &out, size_t header) {
+    return out.size() - header - 4;
+}
+static void response_end(Buffer &out, size_t header) {
+    size_t msg_size = response_size(out, header);
+    if (msg_size > k_max_msg) {
+        out.resize(header + 4);
+        out_err(out, ERR_TOO_BIG, "response is too big.");
+        msg_size = response_size(out, header);
+    }
+    // message header
+    uint32_t len = (uint32_t)msg_size;
+    memcpy(&out[header], &len, 4);
 }
 
 // process 1 request if there is enough data
@@ -282,9 +354,10 @@ static bool try_one_request(Conn *conn) {
         conn->want_close = true;
         return false;   // want close
     }
-    Response resp;
-    do_request(cmd, resp);
-    make_response(resp, conn->outgoing);
+    size_t header_pos = 0;
+    response_begin(conn->outgoing, &header_pos);
+    do_request(cmd, conn->outgoing);
+    response_end(conn->outgoing, header_pos);
 
     // application logic done! remove the request message.
     buf_consume(conn->incoming, 4 + len);


### PR DESCRIPTION
- Introduces typed binary serialization with 4-byte length prefix and type tags (`NIL`, `ERR`, `STR`, `INT`, `DBL`, `ARR`).
- Replaces legacy status+bytes format (breaking change).
- Adds `keys` command and safe hash-map iteration (`hm_foreach`) to enumerate keys.
- Server now writes serialized replies directly; client decodes and pretty-prints nested values.
- README also updated.